### PR TITLE
add `MatchingRules` to `SearchStreamOutput` & `EditHistoryTweet_IDs` to `Tweet`

### DIFF
--- a/resources/tweet.go
+++ b/resources/tweet.go
@@ -3,26 +3,27 @@ package resources
 import "time"
 
 type Tweet struct {
-	ID                 *string             `json:"id"`
-	Text               *string             `json:"text"`
-	Attachments        *TweetAttachments   `json:"attachments,omitempty"`
-	AuthorID           *string             `json:"author_id,omitempty"`
-	ContextAnnotations []ContextAnnotation `json:"context_annotations,omitempty"`
-	ConversationId     *string             `json:"conversation_id,omitempty"`
-	CreatedAt          *time.Time          `json:"created_at,omitempty"`
-	Entities           *TweetEntities      `json:"entities,omitempty"`
-	Geo                *Geo                `json:"geo,omitempty"`
-	InReplyToUserID    *string             `json:"in_reply_to_user_id,omitempty"`
-	Lang               *string             `json:"lang,omitempty"`
-	NonPublicMetrics   *NonPublicMetrics   `json:"non_public_metrics,omitempty"`
-	OrganicMetrics     *OrganicMetrics     `json:"organic_metrics,omitempty"`
-	PossiblySensitive  *bool               `json:"possibly_sensitive,omitempty"`
-	PromotedMetrics    *PromotedMetrics    `json:"promoted_metrics,omitempty"`
-	PublicMetrics      *TweetPublicMetrics `json:"public_metrics,omitempty"`
-	ReferencedTweets   []ReferencedTweet   `json:"referenced_tweets,omitempty"`
-	ReplySettings      *string             `json:"reply_settings,omitempty"`
-	Source             *string             `json:"source,omitempty"`
-	Withheld           *TweetWithheld      `json:"withheld,omitempty"`
+	ID                     *string             `json:"id"`
+	Text                   *string             `json:"text"`
+	Edit_History_Tweet_Ids []*string           `json:"edit_history_tweet_ids"`
+	Attachments            *TweetAttachments   `json:"attachments,omitempty"`
+	AuthorID               *string             `json:"author_id,omitempty"`
+	ContextAnnotations     []ContextAnnotation `json:"context_annotations,omitempty"`
+	ConversationId         *string             `json:"conversation_id,omitempty"`
+	CreatedAt              *time.Time          `json:"created_at,omitempty"`
+	Entities               *TweetEntities      `json:"entities,omitempty"`
+	Geo                    *Geo                `json:"geo,omitempty"`
+	InReplyToUserID        *string             `json:"in_reply_to_user_id,omitempty"`
+	Lang                   *string             `json:"lang,omitempty"`
+	NonPublicMetrics       *NonPublicMetrics   `json:"non_public_metrics,omitempty"`
+	OrganicMetrics         *OrganicMetrics     `json:"organic_metrics,omitempty"`
+	PossiblySensitive      *bool               `json:"possibly_sensitive,omitempty"`
+	PromotedMetrics        *PromotedMetrics    `json:"promoted_metrics,omitempty"`
+	PublicMetrics          *TweetPublicMetrics `json:"public_metrics,omitempty"`
+	ReferencedTweets       []ReferencedTweet   `json:"referenced_tweets,omitempty"`
+	ReplySettings          *string             `json:"reply_settings,omitempty"`
+	Source                 *string             `json:"source,omitempty"`
+	Withheld               *TweetWithheld      `json:"withheld,omitempty"`
 }
 
 type TweetAttachments struct {

--- a/resources/tweet.go
+++ b/resources/tweet.go
@@ -3,27 +3,27 @@ package resources
 import "time"
 
 type Tweet struct {
-	ID                     *string             `json:"id"`
-	Text                   *string             `json:"text"`
-	Edit_History_Tweet_Ids []*string           `json:"edit_history_tweet_ids"`
-	Attachments            *TweetAttachments   `json:"attachments,omitempty"`
-	AuthorID               *string             `json:"author_id,omitempty"`
-	ContextAnnotations     []ContextAnnotation `json:"context_annotations,omitempty"`
-	ConversationId         *string             `json:"conversation_id,omitempty"`
-	CreatedAt              *time.Time          `json:"created_at,omitempty"`
-	Entities               *TweetEntities      `json:"entities,omitempty"`
-	Geo                    *Geo                `json:"geo,omitempty"`
-	InReplyToUserID        *string             `json:"in_reply_to_user_id,omitempty"`
-	Lang                   *string             `json:"lang,omitempty"`
-	NonPublicMetrics       *NonPublicMetrics   `json:"non_public_metrics,omitempty"`
-	OrganicMetrics         *OrganicMetrics     `json:"organic_metrics,omitempty"`
-	PossiblySensitive      *bool               `json:"possibly_sensitive,omitempty"`
-	PromotedMetrics        *PromotedMetrics    `json:"promoted_metrics,omitempty"`
-	PublicMetrics          *TweetPublicMetrics `json:"public_metrics,omitempty"`
-	ReferencedTweets       []ReferencedTweet   `json:"referenced_tweets,omitempty"`
-	ReplySettings          *string             `json:"reply_settings,omitempty"`
-	Source                 *string             `json:"source,omitempty"`
-	Withheld               *TweetWithheld      `json:"withheld,omitempty"`
+	ID                  *string             `json:"id"`
+	Text                *string             `json:"text"`
+	EditHistoryTweetIDs []*string           `json:"edit_history_tweet_ids"`
+	Attachments         *TweetAttachments   `json:"attachments,omitempty"`
+	AuthorID            *string             `json:"author_id,omitempty"`
+	ContextAnnotations  []ContextAnnotation `json:"context_annotations,omitempty"`
+	ConversationId      *string             `json:"conversation_id,omitempty"`
+	CreatedAt           *time.Time          `json:"created_at,omitempty"`
+	Entities            *TweetEntities      `json:"entities,omitempty"`
+	Geo                 *Geo                `json:"geo,omitempty"`
+	InReplyToUserID     *string             `json:"in_reply_to_user_id,omitempty"`
+	Lang                *string             `json:"lang,omitempty"`
+	NonPublicMetrics    *NonPublicMetrics   `json:"non_public_metrics,omitempty"`
+	OrganicMetrics      *OrganicMetrics     `json:"organic_metrics,omitempty"`
+	PossiblySensitive   *bool               `json:"possibly_sensitive,omitempty"`
+	PromotedMetrics     *PromotedMetrics    `json:"promoted_metrics,omitempty"`
+	PublicMetrics       *TweetPublicMetrics `json:"public_metrics,omitempty"`
+	ReferencedTweets    []ReferencedTweet   `json:"referenced_tweets,omitempty"`
+	ReplySettings       *string             `json:"reply_settings,omitempty"`
+	Source              *string             `json:"source,omitempty"`
+	Withheld            *TweetWithheld      `json:"withheld,omitempty"`
 }
 
 type TweetAttachments struct {

--- a/tweet/filteredstream/types/response.go
+++ b/tweet/filteredstream/types/response.go
@@ -33,8 +33,8 @@ func (r *DeleteRulesOutput) HasPartialError() bool {
 }
 
 type SearchStreamMatchedRule struct {
-	Tag string `json:"tag"`
-	Id  string `json:"id"`
+	Tag *string `json:"tag"`
+	Id  *string `json:"id"`
 }
 
 type SearchStreamOutput struct {

--- a/tweet/filteredstream/types/response.go
+++ b/tweet/filteredstream/types/response.go
@@ -32,6 +32,11 @@ func (r *DeleteRulesOutput) HasPartialError() bool {
 	return !(r.Errors == nil || len(r.Errors) == 0)
 }
 
+type SearchStreamMatchedRule struct {
+	Tag string `json:"tag"`
+	Id  string `json:"id"`
+}
+
 type SearchStreamOutput struct {
 	Data     resources.Tweet `json:"data"`
 	Includes struct {
@@ -41,7 +46,8 @@ type SearchStreamOutput struct {
 		Media  []resources.Media `json:"media,omitempty"`
 		Polls  []resources.Poll  `json:"polls,omitempty"`
 	} `json:"includes,omitempty"`
-	Errors []resources.PartialError `json:"errors,omitempty"`
+	Matching_Rules []SearchStreamMatchedRule `json:"matching_rules,omitempty"`
+	Errors         []resources.PartialError  `json:"errors,omitempty"`
 }
 
 func (r *SearchStreamOutput) HasPartialError() bool {

--- a/tweet/filteredstream/types/response.go
+++ b/tweet/filteredstream/types/response.go
@@ -34,7 +34,7 @@ func (r *DeleteRulesOutput) HasPartialError() bool {
 
 type SearchStreamMatchedRule struct {
 	Tag *string `json:"tag"`
-	Id  *string `json:"id"`
+	ID  *string `json:"id"`
 }
 
 type SearchStreamOutput struct {
@@ -46,8 +46,8 @@ type SearchStreamOutput struct {
 		Media  []resources.Media `json:"media,omitempty"`
 		Polls  []resources.Poll  `json:"polls,omitempty"`
 	} `json:"includes,omitempty"`
-	Matching_Rules []SearchStreamMatchedRule `json:"matching_rules,omitempty"`
-	Errors         []resources.PartialError  `json:"errors,omitempty"`
+	MatchingRules []SearchStreamMatchedRule `json:"matching_rules,omitempty"`
+	Errors        []resources.PartialError  `json:"errors,omitempty"`
 }
 
 func (r *SearchStreamOutput) HasPartialError() bool {


### PR DESCRIPTION
Have a use case where I need the `matching_rules` returned as part of the data when streaming tweets. (Per [twitter API docs](https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream), `matching_rules` is a default field in the data returned by the stream)