### PR TITLE
Ability to set API Key & API Key Secret manually

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,8 +38,8 @@ type NewClientInput struct {
 	AuthenticationMethod AuthenticationMethod
 	OAuthToken           string
 	OAuthTokenSecret     string
-	ApiKey               string
-	ApiKeySecret         string
+	APIKey               string
+	APIKeySecret         string
 	Debug                bool
 }
 
@@ -94,8 +94,8 @@ func NewClient(in *NewClientInput) (*Client, error) {
 	c := Client{
 		Client:               defaultHTTPClient,
 		authenticationMethod: in.AuthenticationMethod,
-		apiKeyOverride:       in.ApiKey,
-		apiKeySecretOverride: in.ApiKeySecret,
+		apiKeyOverride:       in.APIKey,
+		apiKeySecretOverride: in.APIKeySecret,
 		debug:                in.Debug,
 	}
 
@@ -133,8 +133,8 @@ func NewClientWithAccessToken(in *NewClientWithAccessTokenInput) (*Client, error
 }
 
 func (c *Client) authorize(oauthToken, oauthTokenSecret string) error {
-	apiKey := c.ApiKey()
-	apiKeySecret := c.ApiKeySecret()
+	apiKey := c.APIKey()
+	apiKeySecret := c.APIKeySecret()
 	if apiKey == "" || apiKeySecret == "" {
 		return fmt.Errorf("env '%s' and '%s' is required.", APIKeyEnvName, APIKeySecretEnvName)
 	}
@@ -193,14 +193,14 @@ func (c *Client) AuthenticationMethod() AuthenticationMethod {
 	return c.authenticationMethod
 }
 
-func (c *Client) ApiKey() string {
+func (c *Client) APIKey() string {
 	if c.apiKeyOverride != "" {
 		return c.apiKeyOverride
 	}
 	return os.Getenv(APIKeyEnvName)
 }
 
-func (c *Client) ApiKeySecret() string {
+func (c *Client) APIKeySecret() string {
 	if c.apiKeySecretOverride != "" {
 		return c.apiKeySecretOverride
 	}
@@ -225,11 +225,11 @@ func (c *Client) SetAuthenticationMethod(v AuthenticationMethod) {
 	c.authenticationMethod = v
 }
 
-func (c *Client) SetApiKey(v string) {
+func (c *Client) SetAPIKey(v string) {
 	c.apiKeyOverride = v
 }
 
-func (c *Client) SetApiKeySecret(v string) {
+func (c *Client) SetAPIKeySecret(v string) {
 	c.apiKeySecretOverride = v
 }
 

--- a/client.go
+++ b/client.go
@@ -225,14 +225,6 @@ func (c *Client) SetAuthenticationMethod(v AuthenticationMethod) {
 	c.authenticationMethod = v
 }
 
-func (c *Client) SetAPIKey(v string) {
-	c.apiKeyOverride = v
-}
-
-func (c *Client) SetAPIKeySecret(v string) {
-	c.apiKeySecretOverride = v
-}
-
 func (c *Client) SetOAuthToken(v string) {
 	c.oauthToken = v
 }

--- a/client.go
+++ b/client.go
@@ -38,6 +38,8 @@ type NewClientInput struct {
 	AuthenticationMethod AuthenticationMethod
 	OAuthToken           string
 	OAuthTokenSecret     string
+	ApiKey               string
+	ApiKeySecret         string
 	Debug                bool
 }
 
@@ -63,6 +65,8 @@ type Client struct {
 	oauthToken           string
 	oauthConsumerKey     string
 	signingKey           string
+	apiKeyOverride       string
+	apiKeySecretOverride string
 	debug                bool
 }
 
@@ -90,6 +94,8 @@ func NewClient(in *NewClientInput) (*Client, error) {
 	c := Client{
 		Client:               defaultHTTPClient,
 		authenticationMethod: in.AuthenticationMethod,
+		apiKeyOverride:       in.ApiKey,
+		apiKeySecretOverride: in.ApiKeySecret,
 		debug:                in.Debug,
 	}
 
@@ -127,8 +133,8 @@ func NewClientWithAccessToken(in *NewClientWithAccessTokenInput) (*Client, error
 }
 
 func (c *Client) authorize(oauthToken, oauthTokenSecret string) error {
-	apiKey := os.Getenv(APIKeyEnvName)
-	apiKeySecret := os.Getenv(APIKeySecretEnvName)
+	apiKey := c.ApiKey()
+	apiKeySecret := c.ApiKeySecret()
 	if apiKey == "" || apiKeySecret == "" {
 		return fmt.Errorf("env '%s' and '%s' is required.", APIKeyEnvName, APIKeySecretEnvName)
 	}
@@ -187,6 +193,20 @@ func (c *Client) AuthenticationMethod() AuthenticationMethod {
 	return c.authenticationMethod
 }
 
+func (c *Client) ApiKey() string {
+	if c.apiKeyOverride != "" {
+		return c.apiKeyOverride
+	}
+	return os.Getenv(APIKeyEnvName)
+}
+
+func (c *Client) ApiKeySecret() string {
+	if c.apiKeySecretOverride != "" {
+		return c.apiKeySecretOverride
+	}
+	return os.Getenv(APIKeySecretEnvName)
+}
+
 func (c *Client) OAuthToken() string {
 	return c.oauthToken
 }
@@ -203,6 +223,14 @@ func (c *Client) SetAccessToken(v string) {
 
 func (c *Client) SetAuthenticationMethod(v AuthenticationMethod) {
 	c.authenticationMethod = v
+}
+
+func (c *Client) SetApiKey(v string) {
+	c.apiKeyOverride = v
+}
+
+func (c *Client) SetApiKeySecret(v string) {
+	c.apiKeySecretOverride = v
 }
 
 func (c *Client) SetOAuthToken(v string) {

--- a/client_test.go
+++ b/client_test.go
@@ -38,8 +38,8 @@ func (tp testParameter) ParameterMap() map[string]string { return nil }
 type gotwiClientField struct {
 	AuthenticationMethod gotwi.AuthenticationMethod
 	AccessToken          string
-	ApiKey               string
-	ApiKeySecret         string
+	APIKey               string
+	APIKeySecret         string
 	OAuthToken           string
 	OAuthConsumerKey     string
 	SigningKey           string
@@ -82,8 +82,8 @@ func Test_NewClient(t *testing.T) {
 			expect: gotwiClientField{
 				AuthenticationMethod: gotwi.AuthenMethodOAuth1UserContext,
 				AccessToken:          "",
-				ApiKey:               "api-key",
-				ApiKeySecret:         "api-key-secret",
+				APIKey:               "api-key",
+				APIKeySecret:         "api-key-secret",
 				OAuthToken:           "oauth-token",
 				OAuthConsumerKey:     "api-key",
 				SigningKey:           "api-key-secret&oauth-token-secret",
@@ -102,8 +102,8 @@ func Test_NewClient(t *testing.T) {
 			expect: gotwiClientField{
 				AuthenticationMethod: gotwi.AuthenMethodOAuth1UserContext,
 				AccessToken:          "",
-				ApiKey:               "api-key",
-				ApiKeySecret:         "api-key-secret",
+				APIKey:               "api-key",
+				APIKeySecret:         "api-key-secret",
 				OAuthToken:           "oauth-token",
 				OAuthConsumerKey:     "api-key",
 				SigningKey:           "api-key-secret&oauth-token-secret",
@@ -119,15 +119,15 @@ func Test_NewClient(t *testing.T) {
 			},
 			in: &gotwi.NewClientInput{
 				AuthenticationMethod: gotwi.AuthenMethodOAuth2BearerToken,
-				ApiKey:               "override-api-key",
-				ApiKeySecret:         "override-api-key-secret",
+				APIKey:               "override-api-key",
+				APIKeySecret:         "override-api-key-secret",
 			},
 			wantErr: false,
 			expect: gotwiClientField{
 				AuthenticationMethod: gotwi.AuthenMethodOAuth2BearerToken,
 				AccessToken:          "access_token",
-				ApiKey:               "override-api-key",
-				ApiKeySecret:         "override-api-key-secret",
+				APIKey:               "override-api-key",
+				APIKeySecret:         "override-api-key-secret",
 				OAuthConsumerKey:     "override-api-key",
 			},
 		},
@@ -228,8 +228,8 @@ func Test_NewClient(t *testing.T) {
 			assert.NoError(tt, err)
 			assert.Equal(tt, c.expect.AuthenticationMethod, gc.AuthenticationMethod())
 			assert.Equal(tt, c.expect.AccessToken, gc.AccessToken())
-			assert.Equal(tt, c.expect.ApiKey, gc.ApiKey())
-			assert.Equal(tt, c.expect.ApiKeySecret, gc.ApiKeySecret())
+			assert.Equal(tt, c.expect.APIKey, gc.APIKey())
+			assert.Equal(tt, c.expect.APIKeySecret, gc.APIKeySecret())
 			assert.Equal(tt, c.expect.OAuthToken, gc.OAuthToken())
 			assert.Equal(tt, c.expect.OAuthConsumerKey, gc.OAuthConsumerKey())
 			assert.Equal(tt, c.expect.SigningKey, gc.SigningKey())


### PR DESCRIPTION
These changes enable setting Twitter API Key & API Key Secret manually, without removing any existing functionality.