### PR TITLE
Add field for community ID on posts

### DIFF
--- a/fields/tweet_fields.go
+++ b/fields/tweet_fields.go
@@ -24,6 +24,7 @@ const (
 	TweetFieldText               TweetField = "text"
 	TweetFieldWithheld           TweetField = "withheld"
 	TweetFieldNoteTweet          TweetField = "note_tweet"
+	TweetFieldCommunityID        TweetField = "community_id"
 )
 
 func (f TweetField) String() string {


### PR DESCRIPTION
The [announcement of the support to fetch the ID of a Community on a post in the API](https://x.com/tapshah21/status/1860061806653317126) was made on 11/22/24. This PR updates `gotwi` to enable clients to include this field in requests for posts.