### PR TITLE
Fix Media.alt_text field type to match Twitter API specification

### DIFF
--- a/resources/fields.go
+++ b/resources/fields.go
@@ -25,7 +25,7 @@ type Media struct {
 	PromotedMetrics  map[string]*int  `json:"promoted_metrics,omitempty"`
 	PublicMetrics    map[string]*int  `json:"public_metrics,omitempty"`
 	Width            *int             `json:"width,omitempty"`
-	AltText          *int             `json:"alt_text,omitempty"`
+	AltText          *string          `json:"alt_text,omitempty"`
 	Variants         []IncludeVariant `json:"variants,omitempty"`
 }
 


### PR DESCRIPTION
This PR fixes #325 by changing the type of `alt_text` field in Media struct from `*int` to `*string` to match Twitter API specification.

### Changes
- Update `resources/fields.go`: change Media.alt_text type from `*int` to `*string`

This fixes JSON unmarshal errors when parsing media objects with alt_text field in filtered stream responses.